### PR TITLE
In the cases of both Companies and People, I removed the documentation o...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+bb
 Batchbook API
 =============
 

--- a/sections/companies.md
+++ b/sections/companies.md
@@ -20,7 +20,11 @@ Each request is limited to 30 companies returned.  To query the next collection,
 
 * `GET /api/v1/companies.xml or .json` returns a collection of companies.
 * `GET /api/v1/companies.xml?page=2` returns the next collection of companies.
-* `GET /api/v1/companies.xml?email=joe.smith@example.com` returns the companies who have the email address listed.  (This is an exact search.  So searching for @gmail won't work. If there is a request for this, file an issue please)
+* `GET /api/v1/companies.xml?exact_email=info@example.com` returns the
+  companies who have the email address info@example.com.
+
+Other Queries:
+
 * `GET /api/v1/companies.xml?tags=awesome` returns the companies who have the tag address listed.
 * `GET /api/v1/companies.xml?name=Batchblue` returns all companies that contain "Batchblue"  Note: This is effectively a LIKE query.
 * `GET /api/v1/companies.xml?updated_since=2012-11-20T11:05:15-05:00` returns all companies who have been updated since the time passed in.

--- a/sections/people.md
+++ b/sections/people.md
@@ -19,9 +19,13 @@ Each request is limited to 30 people returned.  To query the next collection, us
 
 * `GET /api/v1/people.xml or .json` returns a collection of people.
 * `GET /api/v1/people.xml?page=2` returns the next collection of people.
-* `GET /api/v1/people.xml?email=joe.smith@example.com` returns the people who have the email address listed.  (This is an exact search.  So searching for @gmail won't work. If there is a request for this, file an issue please)
+* `GET /api/v1/people.xml?exact_email=joe.smith@example.com` returns
+  anyone with the exact email joe.smith@example.com. 
+
+Other queries:
+
 * `GET /api/v1/people.xml?tags=awesome` returns the people who have the tag address listed.
-* `GET /api/v1/people.xml?name=Joe` returns all people who have "Joe" in their name. [Joe Smith, Joey Bag'ODonuts]   Note: This is effectively a LIKE query.
+* `GET /api/v1/people.xml?name=Joe` returns all people who have "Joe" in their name. [Joe Smith, Joey Bag'ODonuts]   
 * `GET /api/v1/people.xml?updated_since=2012-11-20T11:05:15-05:00` returns all people who have been updated since the time passed in.
 * `GET /api/v1/people.xml?updated_before=2012-11-20T11:05:15-05:00` returns all people who have been updated before the time passed in.
 * `GET /api/v1/people.xml?state=RI` Useful if you want to query all of the people who have an address in a particular state.


### PR DESCRIPTION
...f the nearly unexplainable email fragment search.  It's still supported in this API version, but it's no longer illustrated in the docs.  Added documentation for the newly delivered exact_email query.
